### PR TITLE
Improve Solana RPC handling and add devnet tests

### DIFF
--- a/pumpdotfun_sdk/global_account.py
+++ b/pumpdotfun_sdk/global_account.py
@@ -3,6 +3,7 @@ Global account management for PumpDotFun SDK.
 """
 
 import struct
+import base64
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from solana.publickey import PublicKey
@@ -100,12 +101,17 @@ class GlobalAccountManager:
         try:
             global_account_address = self.get_global_account_address()
             account_info = await self.rpc_client.get_account_info(global_account_address)
-            
+
             if not account_info.value:
                 raise NetworkError("Global account not found")
-            
-            # Parse account data
-            data = self._parse_global_account_data(account_info.value.data)
+
+            raw_data = account_info.value.data
+            if isinstance(raw_data, (list, tuple)):
+                raw_data = base64.b64decode(raw_data[0])
+            elif isinstance(raw_data, str):
+                raw_data = base64.b64decode(raw_data)
+
+            data = self._parse_global_account_data(raw_data)
             
             # Update cache
             self._cached_data = data

--- a/pumpdotfun_sdk/utils.py
+++ b/pumpdotfun_sdk/utils.py
@@ -124,8 +124,20 @@ async def wait_for_confirmation(
             
             if response.value and response.value[0]:
                 status = response.value[0]
-                if status.confirmation_status and status.confirmation_status.value >= SolanaCommitment(commitment).value:
-                    return True
+                confirm_status = getattr(status, "confirmation_status", None)
+                if confirm_status:
+                    # Support both string statuses and objects with `.value`
+                    confirm_status = getattr(confirm_status, "value", confirm_status)
+                    try:
+                        levels = ["processed", "confirmed", "finalized"]
+                        status_level = levels.index(confirm_status)
+                        required_level = levels.index(SolanaCommitment(commitment))
+                        if status_level >= required_level:
+                            return True
+                    except ValueError:
+                        logger.warning(
+                            f"Unknown confirmation status: {confirm_status}"
+                        )
                     
         except Exception as e:
             logger.warning(f"Error checking transaction status: {e}")

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,59 @@
+"""Tests for recently fixed bugs."""
+
+import unittest
+import asyncio
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from solana.publickey import PublicKey
+
+from pumpdotfun_sdk.utils import wait_for_confirmation
+from pumpdotfun_sdk.events import EventManager
+from pumpdotfun_sdk.global_account import GlobalAccountManager, GlobalAccountData
+
+
+class TestWaitForConfirmation(unittest.TestCase):
+    """Ensure wait_for_confirmation handles string statuses."""
+
+    def test_confirmation_status_string(self):
+        async def run_test():
+            mock_client = AsyncMock()
+            status = SimpleNamespace(confirmation_status="finalized")
+            mock_client.get_signature_statuses.return_value = SimpleNamespace(value=[status])
+            return await wait_for_confirmation(mock_client, "sig", commitment="confirmed", timeout=1)
+
+        result = asyncio.run(run_test())
+        self.assertTrue(result)
+
+
+class TestParseLogMessage(unittest.TestCase):
+    """Ensure EventManager parses dict-based messages."""
+
+    def test_dict_message_parsing(self):
+        manager = EventManager(AsyncMock(), "wss://example.com")
+        message = {"result": {"logs": ["Program log: CreateEvent"]}}
+        event_data = manager._parse_log_message(message)
+        self.assertIsNotNone(event_data)
+        self.assertEqual(event_data["event_type"], "createEvent")
+
+
+class TestGlobalAccountManager(unittest.TestCase):
+    """Ensure global account data handles base64 encoded responses."""
+
+    def test_base64_decoding(self):
+        raw = b"\x00" * 200
+        encoded = base64.b64encode(raw).decode("utf-8")
+
+        mock_client = AsyncMock()
+        account_info = SimpleNamespace(value=SimpleNamespace(data=[encoded, "base64"]))
+        mock_client.get_account_info.return_value = account_info
+
+        manager = GlobalAccountManager(mock_client, PublicKey("11111111111111111111111111111111"))
+
+        async def run_test():
+            return await manager.fetch_global_account_data(force_refresh=True)
+
+        data = asyncio.run(run_test())
+        self.assertIsInstance(data, GlobalAccountData)
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,7 @@ from pumpdotfun_sdk.bonding_curve import BondingCurveCalculator
 from pumpdotfun_sdk.amm import AMMCalculator
 
 
-class TestPumpDotFunSDK(unittest.TestCase):
+class TestPumpDotFunSDK(unittest.IsolatedAsyncioTestCase):
     """Test cases for main SDK functionality."""
     
     def setUp(self):
@@ -251,7 +251,7 @@ class TestEventHandling(unittest.TestCase):
         self.assertIn("timestamp", result)
 
 
-class TestIntegration(unittest.TestCase):
+class TestIntegration(unittest.IsolatedAsyncioTestCase):
     """Integration tests for the SDK."""
     
     def setUp(self):

--- a/tests/test_devnet.py
+++ b/tests/test_devnet.py
@@ -1,0 +1,25 @@
+"""Integration test against Solana devnet."""
+
+import unittest
+import asyncio
+
+from solana.rpc.async_api import AsyncClient
+from solana.publickey import PublicKey
+
+
+DEVNET_PUBLIC_KEY = "GkgkJyLRB5gWHxvv1MrAUefLAF7S9c17593sYnwXAdwp"
+
+
+class TestDevnetConnectivity(unittest.TestCase):
+    """Verify that the Solana devnet is reachable."""
+
+    def test_get_balance(self):
+        async def run_test():
+            client = AsyncClient("https://api.devnet.solana.com")
+            resp = await client.get_balance(PublicKey(DEVNET_PUBLIC_KEY))
+            await client.close()
+            return resp.value
+
+        balance = asyncio.run(run_test())
+        self.assertIsInstance(balance, int)
+

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -265,7 +265,7 @@ class TestEventObjectCreation(unittest.TestCase):
             self.event_manager._create_event_object("unknown_event", event_data)
 
 
-class TestEventProcessing(unittest.TestCase):
+class TestEventProcessing(unittest.IsolatedAsyncioTestCase):
     """Test event processing functionality."""
     
     def setUp(self):
@@ -370,7 +370,7 @@ class TestEventProcessing(unittest.TestCase):
             await self.event_manager._process_message(mock_message)
 
 
-class TestEventManagerLifecycle(unittest.TestCase):
+class TestEventManagerLifecycle(unittest.IsolatedAsyncioTestCase):
     """Test EventManager lifecycle management."""
     
     def setUp(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,9 +246,9 @@ class TestErrorClasses(unittest.TestCase):
         self.assertIsInstance(error, Exception)
 
 
-class TestAsyncUtils(unittest.TestCase):
+class TestAsyncUtils(unittest.IsolatedAsyncioTestCase):
     """Test async utility functions."""
-    
+
     @patch('pumpdotfun_sdk.utils.asyncio.sleep')
     async def test_wait_for_confirmation_success(self, mock_sleep):
         """Test successful transaction confirmation."""
@@ -258,8 +258,7 @@ class TestAsyncUtils(unittest.TestCase):
         mock_client = AsyncMock()
         mock_response = Mock()
         mock_response.value = [Mock()]
-        mock_response.value[0].confirmation_status = Mock()
-        mock_response.value[0].confirmation_status.value = 1
+        mock_response.value[0].confirmation_status = "finalized"
         mock_client.get_signature_statuses.return_value = mock_response
         
         result = await wait_for_confirmation(


### PR DESCRIPTION
## Summary
- handle string-based confirmation statuses for Solana 0.28.1
- parse WebSocket messages as dicts or objects
- decode base64 account data before parsing
- add regression tests and devnet connectivity check
- execute async tests with IsolatedAsyncioTestCase to avoid coroutine warnings

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689865fe6cb08333b515f3dac092451e