### PR TITLE
feat: add pumpportal backend for token trades

### DIFF
--- a/pumpdotfun_sdk/__init__.py
+++ b/pumpdotfun_sdk/__init__.py
@@ -10,6 +10,7 @@ from .types import (
     PriorityFee,
     TransactionResult,
     PumpFunEventType,
+    BackendType,
     CreateEvent,
     TradeEvent,
     CompleteEvent
@@ -21,9 +22,10 @@ __author__ = "Manus AI"
 __all__ = [
     "PumpDotFunSDK",
     "CreateTokenMetadata",
-    "PriorityFee", 
+    "PriorityFee",
     "TransactionResult",
     "PumpFunEventType",
+    "BackendType",
     "CreateEvent",
     "TradeEvent",
     "CompleteEvent"

--- a/pumpdotfun_sdk/types.py
+++ b/pumpdotfun_sdk/types.py
@@ -45,6 +45,12 @@ class PumpFunEventType(Enum):
     COMPLETE_EVENT = "completeEvent"
 
 
+class BackendType(Enum):
+    """Available backends for executing trades."""
+    PUMP_PORTAL = "pump_portal"
+    ON_CHAIN = "on_chain"
+
+
 @dataclass
 class CreateEvent:
     """Token creation event."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,12 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from pumpdotfun_sdk import PumpDotFunSDK
-from pumpdotfun_sdk.types import CreateTokenMetadata, PriorityFee, PumpFunEventType
+from pumpdotfun_sdk.types import (
+    CreateTokenMetadata,
+    PriorityFee,
+    PumpFunEventType,
+    BackendType,
+)
 from pumpdotfun_sdk.utils import validate_slippage, sol_to_lamports, format_sol_amount
 from pumpdotfun_sdk.bonding_curve import BondingCurveCalculator
 from pumpdotfun_sdk.amm import AMMCalculator
@@ -52,7 +57,7 @@ class TestPumpDotFunSDK(unittest.IsolatedAsyncioTestCase):
         listener_id = self.sdk.add_event_listener(
             PumpFunEventType.TRADE_EVENT,
             test_callback
-        )test_create_and_buy_success
+        )
         self.assertIsInstance(listener_id, int)
         
         # Remove listener
@@ -81,6 +86,19 @@ class TestPumpDotFunSDK(unittest.IsolatedAsyncioTestCase):
         )
         self.assertFalse(result.success)
         self.assertIn("must be positive", result.error)
+
+    @patch.object(PumpDotFunSDK, "_portal_request", new_callable=AsyncMock)
+    async def test_buy_pumpportal_backend(self, mock_portal):
+        """Ensure buy uses PumpPortal backend when selected."""
+        mock_portal.return_value = {"success": True, "signature": "sig"}
+        result = await self.sdk.buy(
+            buyer=self.test_keypair,
+            mint=self.test_mint.public_key,
+            buy_amount_sol=1.0,
+            backend=BackendType.PUMP_PORTAL,
+        )
+        self.assertTrue(result.success)
+        mock_portal.assert_called()
 
 
 class TestUtilityFunctions(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `BackendType` enum with PumpPortal and on-chain options
- allow choosing backend for create/buy/sell and wire up PumpPortal API
- add pumpportal request helper and placeholder on-chain instructions
- test PumpPortal backend path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689973f1e62883338e517c08aa21749d